### PR TITLE
Fix: cache access token with cache()->put() for Laravel 12 compatibility

### DIFF
--- a/src/SigmaREST.php
+++ b/src/SigmaREST.php
@@ -114,8 +114,12 @@ class SigmaREST
         }
         $this->token = $token;
 
-        // Cache the access token for one hour
-        cache(['sigma_access_token' => $this->token], 60);
+        // Cache the access token for one hour.
+        // Use cache()->put() (positional TTL) rather than the array-set form cache([...], 60):
+        // under Laravel 12 the array-set helper calls app('cache')->put(key, value, ttl: $ttl)
+        // with a NAMED ttl argument, which CacheManager::__call forwards via ...$parameters and
+        // throws "Unknown named parameter $ttl" on stores whose put() does not name it $ttl.
+        cache()->put('sigma_access_token', $this->token, 60);
     }
 
     /**


### PR DESCRIPTION
## Summary
`SigmaREST::_authenticate()` cached the access token with the **array-set** form of the cache helper:
```php
cache(['sigma_access_token' => $this->token], 60);
```
Under **Laravel 12**, that helper expands to `app('cache')->put(key, value, ttl: $ttl)` — a **named** `ttl:` argument. `app('cache')` is the `CacheManager`, which has no `put()` and forwards via `__call($method, $parameters)` → `$this->store()->$method(...$parameters)`. On stores whose `put()` signature doesn't name the parameter `$ttl`, PHP throws **`Error: Unknown named parameter $ttl`** (`Illuminate/Cache/CacheManager.php`). Laravel 9 passed the TTL positionally, so this only surfaces on 12.

## Impact
Every Sigma REST authentication throws during token caching, so any consumer on Laravel 12 fails to connect to Sigma. Surfaced while upgrading Curator to Laravel 12 / Winter 1.3 (Curator PR #1535): the Sigma connection check never completes.

## Fix
Use `cache()->put('sigma_access_token', $this->token, 60)` (positional TTL). This avoids the array-set/named-argument path entirely and works on Laravel 9 through 12. (Lines 99-100, which use `cache()->has()` / `cache('key')`, are already L12-safe.)

## Verification
- `php -l` clean.
- On a Laravel 12 app (v12.61.0): `cache()->put('sigma_access_token','x',60)` returns `true`, whereas the old `cache(['sigma_access_token'=>'x'],60)` path throws `Unknown named parameter $ttl` in CI.

Once merged + tagged (e.g. `0.0.6`), Curator bumps `interworks/sigmarest` to pick it up.